### PR TITLE
Fix FF4 test bug; stop wrapping H1, H2, etc with <div>

### DIFF
--- a/src/wysihat/formatting.js
+++ b/src/wysihat/formatting.js
@@ -182,10 +182,10 @@ WysiHat.Formatting = (function() {
         var element = node.cloneNode(false);
 
         if (tagName == "span") {
-          if ($(node).getStyle("fontWeight") == "bold") {
+          if (node.style['fontWeight'] == "bold") {
             element = new Element("strong");
 
-          } else if ($(node).getStyle("fontStyle") == "italic") {
+          } else if (node.style['fontStyle'] == "italic") {
             element = new Element("em");
           }
         }

--- a/src/wysihat/formatting.js
+++ b/src/wysihat/formatting.js
@@ -80,6 +80,11 @@ WysiHat.Formatting = (function() {
               mode = EXPECTING_LIST_ITEM;
             }
 
+            // if it's a header element, set the line so we don't wrap it in a div
+            if (isHeaderElement(tagName)) {
+              line = lineContainer = new Element(tagName);
+            }
+
           } else if (isLineBreak(tagName)) {
             // if it's a br, and the previous accumulation was a br,
             // remove the previous accumulation and flush
@@ -115,7 +120,7 @@ WysiHat.Formatting = (function() {
 
       function close(tagName) {
         if (mode == ACCUMULATING_LINE) {
-          if (isLineElement(tagName)) {
+          if (isLineElement(tagName) || isHeaderElement(tagName)) {
             flush();
           }
 
@@ -142,11 +147,15 @@ WysiHat.Formatting = (function() {
       }
 
       function isBlockElement(tagName) {
-        return isLineElement(tagName) || isListElement(tagName);
+        return isLineElement(tagName) || isListElement(tagName) || isHeaderElement(tagName);
       }
 
       function isLineElement(tagName) {
         return tagName == "p" || tagName == "div";
+      }
+
+      function isHeaderElement(tagName) {
+        return tagName == 'h1' || tagName == 'h2' || tagName == 'h3' || tagName == 'h4' || tagName == 'h5' || tagName == 'h6';
       }
 
       function isListElement(tagName) {

--- a/test/unit/formatting_test.js
+++ b/test/unit/formatting_test.js
@@ -121,6 +121,17 @@ new Test.Unit.Runner({
         '<ul><li>one</li><li>two</li></ul><div>not</div>',
         getApplicationMarkupFrom('<ul><li>one</li><li>two</li></ul><div>not</div>')
       );
+
+      runner.assertEqual(
+        '<div>Paragraph</div><h1>Header</h1><div>Paragraph</div>',
+        getApplicationMarkupFrom('<div>Paragraph</div><h1>Header</h1><div>Paragraph</div>')
+      );
+      
+      runner.assertEqual(
+        '<div>Paragraph</div><h1>Header <em>Italic header</em> more header</h1><div>Paragraph</div>',
+        getApplicationMarkupFrom('<div>Paragraph</div><h1>Header <span class="Apple-style-span" style="font-style: italic;">Italic header</span> more header</h1><div>Paragraph</div>')
+      );
+
     } else if (Prototype.Browser.Gecko) {
       runner.assertEqual(
         '<div>Here is some basic text<br></div><div>with a line break.</div><div><br></div><div>And maybe another paragraph<br></div>',
@@ -178,6 +189,14 @@ new Test.Unit.Runner({
         '<ul><li>one</li><li>two</li></ul><div>not<br></div>',
         getApplicationMarkupFrom('<ul><li>one</li><li>two</li></ul>not<br>')
       );
+      runner.assertEqual(
+        '<div>Paragraph</div><h1>Header</h1><div>Paragraph</div>',
+        getApplicationMarkupFrom('<div>Paragraph</div><h1>Header</h1><div>Paragraph</div>')
+      );
+      runner.assertEqual(
+        '<div>Paragraph</div><h1>Header <em>Italic header</em> more header</h1><div>Paragraph</div>',
+        getApplicationMarkupFrom('<div>Paragraph</div><h1>Header <span style="font-style: italic;">Italic header</span> more header</h1><div>Paragraph</div>')
+      );
     } else if (Prototype.Browser.IE) {
       runner.assertEqual(
         '<DIV><BR></DIV>',
@@ -234,6 +253,14 @@ new Test.Unit.Runner({
       runner.assertEqual(
         '<UL>\r\n<LI>one</LI>\r\n<LI>two</LI></UL>\r\n<DIV>not</DIV>',
         getApplicationMarkupFrom('<UL>\n<LI>one</LI>\n<LI>two</LI></UL>\n<P>not</P>')
+      );
+      runner.assertEqual(
+        '<DIV>Paragraph</DIV>\r\n<H1>Header</H1>\r\n<DIV>Paragraph</DIV>',
+        getApplicationMarkupFrom('<DIV>Paragraph</DIV>\n<H1>Header</H1>\n<DIV>Paragraph</DIV>')
+      );
+      runner.assertEqual(
+        '<DIV>Paragraph</DIV>\r\n<H1>Header <EM>italic</EM> more header</H1>\r\n<DIV>Paragraph</DIV>',
+        getApplicationMarkupFrom('<DIV>Paragraph</DIV>\n<H1>Header <EM>italic</EM> more header</H1>\n<DIV>Paragraph</DIV>')
       );
     }
   }

--- a/test/unit/formatting_test.js
+++ b/test/unit/formatting_test.js
@@ -25,8 +25,8 @@ new Test.Unit.Runner({
         '<div>Here is some basic text</div><div>with a line break.</div><div class="paragraph_break"><br></div><div>And maybe another paragraph</div>',
         getBrowserMarkupFrom('<div>Here is some basic text</div><div>with a line break.</div><div class=\"paragraph_break\"><br /></div><div>And maybe another paragraph</div>')
       );
-      runner.assertEqual(
-        '<div>Some <span style="font-weight: bold;" class="Apple-style-span">bold</span> text</div>"',
+      runner.assertMatch(
+        '<div>Some <span style="font-weight: bold;?" class="Apple-style-span">bold</span> text</div>"',
         getBrowserMarkupFrom('<div>Some <strong>bold</strong> text</div>"')
       );
     } else if (Prototype.Browser.IE) {


### PR DESCRIPTION
Two minor commits:

First, FF4 does not arbitrarily add a semicolon to a style attribute; the test relied on that behavior in FF3, and broke in FF4. Commit should be self-explanatory.

Second, getApplicationMarkupFrom was wrapping H1-H6 in DIV elements; that does not seem like desired behavior. I fixed it, tests included.

This maybe should be generalized eventually to any block, but H1-H6 seem like the most important ones.

David

(Congrats on the launch, hope you get some time to enjoy the snow days!)
