### PR TITLE
Fix problem with selecting text via the mouse in IE9

### DIFF
--- a/src/wysihat/dom/ierange.js
+++ b/src/wysihat/dom/ierange.js
@@ -446,4 +446,6 @@ if (!window.getSelection) {
     var selection = new Selection(document);
     return function() { return selection; };
   })();
+
+  window.getSelection.custom = true;
 }

--- a/src/wysihat/dom/selection.js
+++ b/src/wysihat/dom/selection.js
@@ -1,7 +1,7 @@
 //= require "./ierange"
 //= require "./range"
 
-if (Prototype.Browser.IE) {
+if (window.getSelection.custom) {
   Object.extend(Selection.prototype, (function() {
     // TODO: More robust getNode
     function getNode() {


### PR DESCRIPTION
IE9 implements "window.getSelection", and yet wysihat was depending on the internals of the custom getSelection implementation even for IE9. This patch getNode and friends to build on the internal implementation of getSelection, even on IE9.
